### PR TITLE
Read variables from env files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.0.1"
 description = "KeePassXC runner"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = [
+    "python-dotenv>=1.0.1",
+]
 
 [project.scripts]
 keepassxc-run = "keepassxc_run.cli:main"

--- a/src/keepassxc_run/cli.py
+++ b/src/keepassxc_run/cli.py
@@ -38,7 +38,12 @@ def _read_envs(env_files: list[str]) -> dict[str, str]:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("command", nargs="+", help="command to execute")
-    parser.add_argument("--env-file", action="append", default=[], help="Enable Dotenv integration with specific Dotenv files to parse. For example: --env-file=.env")
+    parser.add_argument(
+        "--env-file",
+        action="append",
+        default=[],
+        help="Enable Dotenv integration with specific Dotenv files to parse. For example: --env-file=.env",
+    )
     args = parser.parse_args(sys.argv[1:])
 
     envs = _read_envs(args.env_file)

--- a/src/keepassxc_run/cli.py
+++ b/src/keepassxc_run/cli.py
@@ -22,19 +22,26 @@ def _git_credential_keepassxc(url: str) -> str:
         return credential["string_fields"][attribute]
 
 
+def _read_envs(env_files: list[str]) -> dict[str, str]:
+    """Read environment variables from running environment and env files."""
+    envs = os.environ.copy()
+    for env_file in env_files:
+        env_file_values = dotenv_values(env_file)
+        envs.update(env_file_values)
+    # Fetch secret values from KeePassXC database
+    for key, value in envs.items():
+        if value.startswith("keepassxc://"):
+            envs[key] = _git_credential_keepassxc(value)
+    return envs
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("command", nargs="+", help="command to execute")
     parser.add_argument("--env-file", action="append", default=[], help="Enable Dotenv integration with specific Dotenv files to parse. For example: --env-file=.env")
     args = parser.parse_args(sys.argv[1:])
 
-    envs = os.environ.copy()
-    for env_file in args.env_file:
-        env_file_values = dotenv_values(env_file)
-        envs.update(env_file_values)
-    for key, value in envs.items():
-        if value.startswith("keepassxc://"):
-            envs[key] = _git_credential_keepassxc(value)
+    envs = _read_envs(args.env_file)
     process = subprocess.run(args=args.command, check=False, env=envs)
     sys.exit(process.returncode)
 

--- a/src/keepassxc_run/cli.py
+++ b/src/keepassxc_run/cli.py
@@ -4,6 +4,8 @@ import os
 import sys
 import subprocess
 
+from dotenv import dotenv_values
+
 
 def _git_credential_keepassxc(url: str) -> str:
     """Fetch a credential value by 'git-credential-keepassxc'"""
@@ -23,9 +25,13 @@ def _git_credential_keepassxc(url: str) -> str:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("command", nargs="+", help="command to execute")
+    parser.add_argument("--env-file", action="append", default=[], help="Enable Dotenv integration with specific Dotenv files to parse. For example: --env-file=.env")
     args = parser.parse_args(sys.argv[1:])
 
     envs = os.environ.copy()
+    for env_file in args.env_file:
+        env_file_values = dotenv_values(env_file)
+        envs.update(env_file_values)
     for key, value in envs.items():
         if value.startswith("keepassxc://"):
             envs[key] = _git_credential_keepassxc(value)

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,9 @@ requires-python = ">=3.9"
 name = "keepassxc-run"
 version = "0.0.1"
 source = { editable = "." }
+dependencies = [
+    { name = "python-dotenv" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -12,9 +15,19 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "python-dotenv", specifier = ">=1.0.1" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.6.8" }]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
 
 [[package]]
 name = "ruff"


### PR DESCRIPTION
This PR enables to read variables from env files. For example, there is following `.env` file.

```bash
TEST_PASSWORD=keepassxc://example.com/password
```

If `.env` is passed in `--env-file` option, `keepassxc-run` reads variables in `.env` file and fetch secrets from KeePassXC database. 

```sh
$ keepassxc-run --env-file .env -- printenv TEST_PASSWORD
<secret password in KeePassXC database>
```