### PR TITLE
Use PEP 639 to declare the package license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "keepassxc-run"
 version = "0.1.0"
 description = "KeePassXC runner"
 readme = "README.md"
-license = { text = "MIT License" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Tsunenobu Kai", email = "kai2nenobu@gmail.com" }]
 keywords = ["keepassxc"]
 requires-python = ">=3.9"
@@ -18,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Topic :: Utilities",
     "Topic :: Security",
 ]


### PR DESCRIPTION
According to PEP 639, value of "project.license" should be SPDX license expression.
Removed License classifier as it has been deprecated.

ref: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

This PR changes a package metadata as below.

```diff
-License: MIT License
+License-Expression: MIT
License-File: LICENSE
-Classifier: License :: OSI Approved :: MIT License
```
